### PR TITLE
Init PatternConstructorBase

### DIFF
--- a/lib/egison/matcher-core.rb
+++ b/lib/egison/matcher-core.rb
@@ -1,55 +1,63 @@
 require 'egison/core'
 require 'egison/lazyarray'
-
-class Class
-  include PatternMatch::Matchable
-
-  def unnil(val)
-    if val.empty?
-      [[]]
-    else
-      []
-    end
-  end
-
-  def uncons(val)
-    fail NotImplementedError, "need to define `#{__method__}'"
-  end
-
-  def uncons_stream(val, &block)
-    fail NotImplementedError, "need to define `#{__method__}'"
-  end
-
-  private
-
-  def test_conv_lazy_array(val)
-    fail PatternMatch::PatternNotMatch unless val.respond_to?(:each)
-    Egison::LazyArray.new(val)
-  end
-end
-
 module Egison
   extend self
 
+  module PatternConstructorBase
+    include PatternMatch::Matchable
+
+    def sep(val)
+      val2 = val.clone
+      [val2.shift, val2]
+    end
+
+    def sep!(val)
+      [val.shift, val.clone]
+    end
+
+    def cln_emp_cln(val)
+      [val.clone, [], val.clone]
+    end
+
+    def unnil(val)
+      if val.empty?
+        [[]]
+      else
+        []
+      end
+    end
+
+    def uncons(val)
+      fail NotImplementedError, "need to define `#{__method__}'"
+    end
+
+    def uncons_stream(val, &block)
+      fail NotImplementedError, "need to define `#{__method__}'"
+    end
+
+    private
+      def test_conv_lazy_array!(val)
+        fail PatternMatch::PatternNotMatch unless val.respond_to?(:each)
+        val = Egison::LazyArray.new(val) unless val.is_a?(EgisonArray)
+      end
+  end
+
   class << Struct
+    include PatternConstructorBase
+
     def unnil(val)
       [[]]
     end
 
     def uncons(val)
-      val2 = val.clone
-      x = val2.shift
-      [[x, val2]]
+      [sep(val)]
     end
 
     def unjoin(val)
-      val2 = val.clone
-      xs = []
-      ys = val2.clone
+      val2, xs, ys = cln_emp_cln(val)
       rets = [[xs, ys]]
       until val2.empty?
-        x = val2.shift
-        ys = val2.clone
+        x, ys = sep!(val2)
         xs += [x]
         rets += [[xs, ys]]
       end
@@ -61,29 +69,22 @@ module Egison
   end
 
   class << List
+    include PatternConstructorBase
+
     def uncons(val)
-      val2 = val.clone
-      x = val2.shift
-      [[x, val2]]
+      [sep(val)]
     end
 
     def uncons_stream(val, &block)
-      unless val.is_a?(EgisonArray)
-        val = test_conv_lazy_array(val)
-      end
-      val2 = val.clone
-      x = val2.shift
-      block.([x, val2])
+      test_conv_lazy_array!(val)
+      block.(sep(val))
     end
 
     def unjoin(val)
-      val2 = val.clone
-      xs = []
-      ys = val2.clone
+      val2, xs, ys = cln_emp_cln(val)
       rets = [[xs, ys]]
       until val2.empty?
-        x = val2.shift
-        ys = val2.clone
+        x, ys = sep!(val2)
         xs += [x]
         rets += [[xs, ys]]
       end
@@ -91,16 +92,11 @@ module Egison
     end
 
     def unjoin_stream(val, &block)
-      unless val.is_a?(EgisonArray)
-        val = test_conv_lazy_array(val)
-      end
-      val2 = val.clone
-      xs = []
-      ys = val2.clone
+      test_conv_lazy_array!(val)
+      val2, xs, ys = cln_emp_cln(val)
       block.([xs, ys])
       until val2.empty?
-        x = val2.shift
-        ys = val2.clone
+        x, ys = sep!(val2)
         xs += [x]
         block.([xs, ys])
       end

--- a/lib/egison/matcher-core.rb
+++ b/lib/egison/matcher-core.rb
@@ -50,18 +50,11 @@ module Egison
     end
 
     def uncons(val)
-      [sep(val)]
+      List.uncons(val)
     end
 
     def unjoin(val)
-      val2, xs, ys = cln_emp_cln(val)
-      rets = [[xs, ys]]
-      until val2.empty?
-        x, ys = sep!(val2)
-        xs += [x]
-        rets += [[xs, ys]]
-      end
-      rets
+      List.unjoin(val)
     end
   end
 

--- a/lib/egison/matcher.rb
+++ b/lib/egison/matcher.rb
@@ -10,6 +10,8 @@ module Egison
   end
 
   class << Multiset
+    include PatternConstructorBase
+
     def uncons(val)
       match_all(val) do
         with(List.(*_hs, _x, *_ts)) do
@@ -19,9 +21,7 @@ module Egison
     end
 
     def uncons_stream(val, &block)
-      unless val.is_a?(EgisonArray)
-        val = test_conv_lazy_array(val)
-      end
+      test_conv_lazy_array!(val)
       stream = match_stream(val) {
         with(List.(*_hs, _x, *_ts)) do
           [x, hs + ts]
@@ -31,15 +31,12 @@ module Egison
     end
 
     def unjoin(val)
-      val2 = val.clone
-      xs = []
-      ys = val2.clone
+      val2, xs, ys = cln_emp_cln(val)
       rets = [[xs, ys]]
       if val2.empty?
         rets
       else
-        x = val2.shift
-        ys = val2.clone
+        x, ys = sep!(val2)
         rets2 = unjoin(ys)
         rets = (rets2.map { |xs2, ys2| [xs2, [x] + ys2] }) + (rets2.map { |xs2, ys2| [[x] + xs2, ys2] })
         rets
@@ -47,16 +44,11 @@ module Egison
     end
 
     def unjoin_stream(val, &block)
-      unless val.is_a?(EgisonArray)
-        val = test_conv_lazy_array(val)
-      end
-      val2 = val.clone
-      xs = []
-      ys = val2.clone
+      test_conv_lazy_array!(val)
+      val2, xs, ys = cln_emp_cln(val)
       block.([xs, ys])
       unless val2.empty?
-        x = val2.shift
-        ys = val2.clone
+        x, ys = sep!(val2)
         unjoin_stream(ys) do |xs2, ys2|
           block.([xs2, [x] + ys2]) unless xs2.empty?
           block.([[x] + xs2, ys2])
@@ -66,6 +58,8 @@ module Egison
   end
 
   class << Set
+    include PatternConstructorBase
+
     def uncons(val)
       match_all(val) do
         with(List.(*_, _x, *_)) do
@@ -75,9 +69,7 @@ module Egison
     end
 
     def uncons_stream(val, &block)
-      unless val.is_a?(EgisonArray)
-        val = test_conv_lazy_array(val)
-      end
+      test_conv_lazy_array!(val)
       stream = match_stream(val) {
         with(List.(*_, _x, *_)) do
           [x, val]
@@ -87,15 +79,12 @@ module Egison
     end
 
     def unjoin(val)
-      val2 = val.clone
-      xs = []
-      ys = val2.clone
+      val2, xs, ys = cln_emp_cln(val)
       rets = [[xs, ys]]
       if val2.empty?
         rets
       else
-        x = val2.shift
-        ys2 = val2.clone
+        x, ys2 = sep!(val2)
         rets2 = unjoin(ys2)
         rets = (rets2.map { |xs2, _| [xs2, ys] }) + (rets2.map { |xs2, _ys2| [[x] + xs2, ys] })
         rets
@@ -103,16 +92,11 @@ module Egison
     end
 
     def unjoin_stream(val, &block)
-      unless val.is_a?(EgisonArray)
-        val = test_conv_lazy_array(val)
-      end
-      val2 = val.clone
-      xs = []
-      ys = val2.clone
+      test_conv_lazy_array!(val)
+      val2, xs, ys = cln_emp_cln(val)
       block.([xs, ys])
       unless val2.empty?
-        x = val2.shift
-        ys2 = val2.clone
+        x, ys2 = sep!(val2)
         unjoin_stream(ys2) do |xs2, _|
           block.([xs2, ys]) unless xs2.empty?
           block.([[x] + xs2, ys])

--- a/lib/egison/matcher.rb
+++ b/lib/egison/matcher.rb
@@ -33,14 +33,12 @@ module Egison
     def unjoin(val)
       val2, xs, ys = cln_emp_cln(val)
       rets = [[xs, ys]]
-      if val2.empty?
-        rets
-      else
+      unless val2.empty?
         x, ys = sep!(val2)
         rets2 = unjoin(ys)
         rets = (rets2.map { |xs2, ys2| [xs2, [x] + ys2] }) + (rets2.map { |xs2, ys2| [[x] + xs2, ys2] })
-        rets
       end
+      rets
     end
 
     def unjoin_stream(val, &block)
@@ -81,14 +79,13 @@ module Egison
     def unjoin(val)
       val2, xs, ys = cln_emp_cln(val)
       rets = [[xs, ys]]
-      if val2.empty?
-        rets
-      else
+      unless val2.empty?
         x, ys2 = sep!(val2)
         rets2 = unjoin(ys2)
         rets = (rets2.map { |xs2, _| [xs2, ys] }) + (rets2.map { |xs2, _ys2| [[x] + xs2, ys] })
         rets
       end
+      rets
     end
 
     def unjoin_stream(val, &block)


### PR DESCRIPTION
Introduce `PatternConstructorBase` to refactor matcher and to separate methods from `Class` class.
